### PR TITLE
Enable the dev server to proxy requests with methods other than GET

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -371,6 +371,7 @@ export async function command(commandOptions: CommandOptions) {
           const newPath = reqPath.substr(workerConfig.args.toUrl.length);
           try {
             const response = await got(`${workerConfig.args.fromUrl}${newPath}`, {
+              method: req.method,
               headers: req.headers,
               throwHttpErrors: false,
             });


### PR DESCRIPTION
Currently all proxied requests are passed through as GET since no method is specified. This commit updates the proxied call to pass through the method that the initial request was made with.